### PR TITLE
Issue 12 search for test classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Acceptance Tests As Monitors
 
 1. Include the atam4j maven dependency.
 
-2. Write Junit based tests in the usual manner, with the exception of including them in the main application classpath 
+2. Write Junit based tests in the usual manner, with the exception of adding a `@Monitor` annotation to the class and including them in the main application classpath 
 instead of the tests classpath. This can be done by including them in the `src/main/java directory` instead of the 
 `src/test/java` directory.
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,13 @@ Acceptance Tests As Monitors
 
 2. Write Junit based tests in the usual manner, with the exception of including them in the main application classpath 
 instead of the tests classpath. This can be done by including them in the `src/main/java directory` instead of the 
-`src/test/java` directory. You can either add a `@Monitor` annotation to your test classes and let atam4j detect them or 
+`src/test/java` directory. You can choose to either add a `@Monitor` annotation to your test classes and let atam4j detect them or 
 simply supply an array of classes to the builder.
 
 3. Instantiate `Atam4j` in the `run` method of your dropwizard application class.    
 
-        new Atam4j.Atam4jBuilder()     
-            .withTestClasses(HelloWorldTest.class)     
-            .withEnvironment(environment)      
+        new Atam4j.Atam4jBuilder(environment)     
+            .withTestClasses(HelloWorldTest.class) 
             .build()      
             .initialise();
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@ Acceptance Tests As Monitors
 
 1. Include the atam4j maven dependency.
 
-2. Write Junit based tests in the usual manner, with the exception of adding a `@Monitor` annotation to the class and including them in the main application classpath 
+2. Write Junit based tests in the usual manner, with the exception of including them in the main application classpath 
 instead of the tests classpath. This can be done by including them in the `src/main/java directory` instead of the 
-`src/test/java` directory.
+`src/test/java` directory. You can either add a `@Monitor` annotation to your test classes and let atam4j detect them or 
+simply supply an array of classes to the builder.
 
-3. Instantiate  `Atam4j` in the `run` method of your dropwizard application class.    
+3. Instantiate `Atam4j` in the `run` method of your dropwizard application class.    
 
         new Atam4j.Atam4jBuilder()     
-            .withTestClasses(new Class[]{HelloWorldTest.class})     
+            .withTestClasses(HelloWorldTest.class)     
             .withEnvironment(environment)      
             .build()      
             .initialise();

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <guava.version>18.0</guava.version>
         <slf4j-test.version>1.1.0</slf4j-test.version>
         <junit.version>4.12</junit.version>
+        <reflections.version>0.9.10</reflections.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
         <mockito-core.version>1.10.19</mockito-core.version>
         <cucumber.version>1.1.5</cucumber.version>
@@ -98,6 +99,11 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>${reflections.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTask.java
+++ b/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTask.java
@@ -14,7 +14,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Date;
 import java.util.Optional;
-import java.util.Set;
 
 public class AcceptanceTestsRunnerTask implements Runnable {
 
@@ -48,12 +47,12 @@ public class AcceptanceTestsRunnerTask implements Runnable {
     }
 
     private Class<?>[] getTestClasses(final Optional<Class[]> testClasses) {
-        return testClasses.orElseGet(() -> {
-            final Set<Class<?>> monitors = new Reflections(new ConfigurationBuilder()
+        return testClasses.orElseGet(() ->
+            new Reflections(new ConfigurationBuilder()
                     .setUrls(ClasspathHelper.forJavaClassPath())
                     .setScanners(new SubTypesScanner(), new TypeAnnotationsScanner()))
-                    .getTypesAnnotatedWith(Monitor.class);
-            return monitors.toArray(new Class[monitors.size()]);
-        });
+                    .getTypesAnnotatedWith(Monitor.class)
+                    .stream()
+                    .toArray(Class[]::new));
     }
 }

--- a/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTask.java
+++ b/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTask.java
@@ -4,27 +4,22 @@ import me.atam.atam4j.health.AcceptanceTestsState;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
-import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.scanners.TypeAnnotationsScanner;
-import org.reflections.util.ClasspathHelper;
-import org.reflections.util.ConfigurationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Date;
-import java.util.Optional;
 
 public class AcceptanceTestsRunnerTask implements Runnable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AcceptanceTestsRunnerTask.class);
-    private static AcceptanceTestsState testsState;
 
+    private final AcceptanceTestsState testsState;
     private final Class[] testClasses;
 
-    AcceptanceTestsRunnerTask(final AcceptanceTestsState testsState, final Optional<Class[]> testClasses) {
-        AcceptanceTestsRunnerTask.testsState = testsState;
-        this.testClasses = getTestClasses(testClasses);
+    AcceptanceTestsRunnerTask(final AcceptanceTestsState testsState,
+                              final Class... testClasses) {
+        this.testsState = testsState;
+        this.testClasses = testClasses;
     }
 
     @Override
@@ -44,15 +39,5 @@ public class AcceptanceTestsRunnerTask implements Runnable {
         for (Failure failure: result.getFailures()) {
             LOGGER.error(failure.getDescription().toString(), failure.getException());
         }
-    }
-
-    private Class<?>[] getTestClasses(final Optional<Class[]> testClasses) {
-        return testClasses.orElseGet(() ->
-            new Reflections(new ConfigurationBuilder()
-                    .setUrls(ClasspathHelper.forJavaClassPath())
-                    .setScanners(new SubTypesScanner(), new TypeAnnotationsScanner()))
-                    .getTypesAnnotatedWith(Monitor.class)
-                    .stream()
-                    .toArray(Class[]::new));
     }
 }

--- a/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTaskScheduler.java
+++ b/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTaskScheduler.java
@@ -3,19 +3,18 @@ package me.atam.atam4j;
 import io.dropwizard.setup.Environment;
 import me.atam.atam4j.health.AcceptanceTestsState;
 
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class AcceptanceTestsRunnerTaskScheduler {
 
     private final Environment environment;
-    private final Optional<Class[]> testClasses;
+    private final Class[] testClasses;
     private final long initialDelay;
     private final long period;
     private final TimeUnit unit;
 
     public AcceptanceTestsRunnerTaskScheduler(final Environment environment,
-                                              final Optional<Class[]> testClasses,
+                                              final Class[] testClasses,
                                               final long initialDelay,
                                               final long period,
                                               final TimeUnit unit) {

--- a/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTaskScheduler.java
+++ b/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTaskScheduler.java
@@ -3,21 +3,22 @@ package me.atam.atam4j;
 import io.dropwizard.setup.Environment;
 import me.atam.atam4j.health.AcceptanceTestsState;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class AcceptanceTestsRunnerTaskScheduler {
 
-    private Environment environment;
-    private Class testClasses[];
-    private long initialDelay;
-    private long period;
-    private TimeUnit unit;
+    private final Environment environment;
+    private final Optional<Class[]> testClasses;
+    private final long initialDelay;
+    private final long period;
+    private final TimeUnit unit;
 
-    public AcceptanceTestsRunnerTaskScheduler(Environment environment,
-                                              Class[] testClasses,
-                                              long initialDelay,
-                                              long period,
-                                              TimeUnit unit) {
+    public AcceptanceTestsRunnerTaskScheduler(final Environment environment,
+                                              final Optional<Class[]> testClasses,
+                                              final long initialDelay,
+                                              final long period,
+                                              final TimeUnit unit) {
         this.environment = environment;
         this.testClasses = testClasses;
         this.initialDelay = initialDelay;
@@ -25,14 +26,12 @@ public class AcceptanceTestsRunnerTaskScheduler {
         this.unit = unit;
     }
 
-    public void scheduleAcceptanceTestsRunnerTask(AcceptanceTestsState acceptanceTestsState) {
-        AcceptanceTestsRunnerTask acceptanceTestsRunnerTask = new AcceptanceTestsRunnerTask(acceptanceTestsState, testClasses);
+    public void scheduleAcceptanceTestsRunnerTask(final AcceptanceTestsState acceptanceTestsState) {
         environment.lifecycle().
                 scheduledExecutorService("acceptance-tests-runner").build().scheduleAtFixedRate(
-                acceptanceTestsRunnerTask,
+                new AcceptanceTestsRunnerTask(acceptanceTestsState, testClasses),
                 initialDelay,
                 period,
                 unit);
     }
-
 }

--- a/src/main/java/me/atam/atam4j/Atam4j.java
+++ b/src/main/java/me/atam/atam4j/Atam4j.java
@@ -27,15 +27,14 @@ public class Atam4j {
 
     public static class Atam4jBuilder {
 
-        private Environment environment = null;
+        private Environment environment;
         private Class testClasses[] = null;
         private long initialDelay = 60;
         private long period = 300;
         private TimeUnit unit = TimeUnit.SECONDS;
 
-        public Atam4jBuilder withEnvironment(Environment environment) {
+        public Atam4jBuilder(Environment environment) {
             this.environment = environment;
-            return this;
         }
 
         public Atam4jBuilder withTestClasses(Class[] testClasses) {

--- a/src/main/java/me/atam/atam4j/Monitor.java
+++ b/src/main/java/me/atam/atam4j/Monitor.java
@@ -1,0 +1,11 @@
+package me.atam.atam4j;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Monitor {
+}

--- a/src/main/java/me/atam/atam4j/NoTestClassFoundException.java
+++ b/src/main/java/me/atam/atam4j/NoTestClassFoundException.java
@@ -1,0 +1,8 @@
+package me.atam.atam4j;
+
+public class NoTestClassFoundException extends RuntimeException {
+
+    public NoTestClassFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/me/atam/atam4j/AcceptanceTestsRunnerTaskTest.java
+++ b/src/test/java/me/atam/atam4j/AcceptanceTestsRunnerTaskTest.java
@@ -10,9 +10,6 @@ import org.junit.runner.Result;
 import uk.org.lidalia.slf4jtest.TestLogger;
 import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
-import java.util.Optional;
-
-import static java.util.Optional.empty;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -25,42 +22,28 @@ public class AcceptanceTestsRunnerTaskTest {
 
     @Test
     public void testPassingTestsRun(){
-        Class[] passingTests = {PassingTest.class};
-        assertTrue(runTestsAndGetResult(passingTests).wasSuccessful());
-    }
-
-    @Test
-    public void testPassingTestRunsUsingAnnotation(){
-        assertTrue(runTestsAndGetResult().wasSuccessful());
+        assertTrue(runTestsAndGetResult(PassingTest.class).wasSuccessful());
     }
 
     @Test
     public void testFailingTestFailsAndErrorIsLogged(){
-        Class[] failingTest = {FailingTest.class};
-        assertFalse(runTestsAndGetResult(failingTest).wasSuccessful());
+        assertFalse(runTestsAndGetResult(FailingTest.class).wasSuccessful());
         assertThat(logger.getLoggingEvents(), hasItem(LoggingEventWithThrowableMatcher.hasThrowableThatContainsString("Was expecting false to be true")));
     }
 
     @Test
     public void testPassingAndFailingTestReportsFailure() {
-        Class[] passingAndFailingTest = {FailingTest.class, PassingTest.class};
-        assertFalse(runTestsAndGetResult(passingAndFailingTest).wasSuccessful());
+        assertFalse(runTestsAndGetResult(FailingTest.class, PassingTest.class).wasSuccessful());
     }
 
     @Test
     public void testThatExceptionFromTestsGetsLogged() {
-        Class[] testThatFailsToBeInitialised = {TestThatFailsOnInitialisation.class};
-        assertFalse(runTestsAndGetResult(testThatFailsToBeInitialised ).wasSuccessful());
+        assertFalse(runTestsAndGetResult(TestThatFailsOnInitialisation.class).wasSuccessful());
         assertThat(logger.getLoggingEvents(), hasItem(LoggingEventWithThrowableMatcher.hasThrowableThatContainsString("Nasty Exception")));
     }
 
-    private Result runTestsAndGetResult(Class[] passingTests) {
-        new AcceptanceTestsRunnerTask(acceptanceTestsState, Optional.of(passingTests)).run();
-        return acceptanceTestsState.getResult().get();
-    }
-
-    private Result runTestsAndGetResult() {
-        new AcceptanceTestsRunnerTask(acceptanceTestsState, empty()).run();
+    private Result runTestsAndGetResult(Class... passingTests) {
+        new AcceptanceTestsRunnerTask(acceptanceTestsState, passingTests).run();
         return acceptanceTestsState.getResult().get();
     }
 }

--- a/src/test/java/me/atam/atam4j/AcceptanceTestsRunnerTaskTest.java
+++ b/src/test/java/me/atam/atam4j/AcceptanceTestsRunnerTaskTest.java
@@ -42,13 +42,13 @@ public class AcceptanceTestsRunnerTaskTest {
     }
 
     @Test
-    public void testPassingAndFailingTestReportsFailure(){
+    public void testPassingAndFailingTestReportsFailure() {
         Class[] passingAndFailingTest = {FailingTest.class, PassingTest.class};
         assertFalse(runTestsAndGetResult(passingAndFailingTest).wasSuccessful());
     }
 
     @Test
-    public void testThatExceptionFromTestsGetsLogged(){
+    public void testThatExceptionFromTestsGetsLogged() {
         Class[] testThatFailsToBeInitialised = {TestThatFailsOnInitialisation.class};
         assertFalse(runTestsAndGetResult(testThatFailsToBeInitialised ).wasSuccessful());
         assertThat(logger.getLoggingEvents(), hasItem(LoggingEventWithThrowableMatcher.hasThrowableThatContainsString("Nasty Exception")));

--- a/src/test/java/me/atam/atam4j/AcceptanceTestsRunnerTaskTest.java
+++ b/src/test/java/me/atam/atam4j/AcceptanceTestsRunnerTaskTest.java
@@ -5,12 +5,14 @@ import me.atam.atam4j.ignore.FailingTest;
 import me.atam.atam4j.ignore.PassingTest;
 
 import me.atam.atam4j.ignore.TestThatFailsOnInitialisation;
-import org.apache.log4j.spi.LoggingEvent;
 import org.junit.Test;
 import org.junit.runner.Result;
 import uk.org.lidalia.slf4jtest.TestLogger;
 import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
+import java.util.Optional;
+
+import static java.util.Optional.empty;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -21,11 +23,15 @@ public class AcceptanceTestsRunnerTaskTest {
     AcceptanceTestsState acceptanceTestsState = new AcceptanceTestsState();
     TestLogger logger = TestLoggerFactory.getTestLogger(AcceptanceTestsRunnerTask.class);
 
-
     @Test
     public void testPassingTestsRun(){
         Class[] passingTests = {PassingTest.class};
         assertTrue(runTestsAndGetResult(passingTests).wasSuccessful());
+    }
+
+    @Test
+    public void testPassingTestRunsUsingAnnotation(){
+        assertTrue(runTestsAndGetResult().wasSuccessful());
     }
 
     @Test
@@ -49,9 +55,12 @@ public class AcceptanceTestsRunnerTaskTest {
     }
 
     private Result runTestsAndGetResult(Class[] passingTests) {
-        new AcceptanceTestsRunnerTask(acceptanceTestsState, passingTests).run();
+        new AcceptanceTestsRunnerTask(acceptanceTestsState, Optional.of(passingTests)).run();
         return acceptanceTestsState.getResult().get();
     }
 
-
+    private Result runTestsAndGetResult() {
+        new AcceptanceTestsRunnerTask(acceptanceTestsState, empty()).run();
+        return acceptanceTestsState.getResult().get();
+    }
 }

--- a/src/test/java/me/atam/atam4j/Atam4jBuilderTest.java
+++ b/src/test/java/me/atam/atam4j/Atam4jBuilderTest.java
@@ -19,5 +19,4 @@ public class Atam4jBuilderTest {
         Atam4j.Atam4jBuilder builder = new Atam4j.Atam4jBuilder(null);
         builder.build();
     }
-
 }

--- a/src/test/java/me/atam/atam4j/Atam4jBuilderTest.java
+++ b/src/test/java/me/atam/atam4j/Atam4jBuilderTest.java
@@ -1,8 +1,6 @@
 package me.atam.atam4j;
 
 import io.dropwizard.setup.Environment;
-import me.atam.atam4j.ignore.PassingTest;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -10,34 +8,16 @@ import static org.mockito.Mockito.mock;
 
 public class Atam4jBuilderTest {
 
-    Atam4j.Atam4jBuilder builder = new Atam4j.Atam4jBuilder();
-
     @Test
-    public void givenBuilderNotSuppliedWithEnvironment_whenBuildCalled_thenExceptionThrown(){
-        buildShouldThrowExceptionWithMessage("No Environment specified");
-    }
-
-    @Test
-    public void givenBuilderNotSuppliedWithTestClasses_whenBuildCalled_thenExceptionThrown(){
-        builder.withEnvironment(mock(Environment.class));
-        buildShouldThrowExceptionWithMessage("No test classes or annotation scanning specified");
-    }
-
-    @Test
-    public void givenBuilderSuppliedWithAllMandatoryParams_whenBuildCalled_thenManagerReturned(){
-        builder.withEnvironment(mock(Environment.class));
-        builder.withTestClasses(new Class[]{PassingTest.class});
+    public void givenBuilderConstructedWithValidEnvironment_whenBuildCalled_thenManagerReturned() {
+        Atam4j.Atam4jBuilder builder = new Atam4j.Atam4jBuilder(mock(Environment.class));
         Assert.assertNotNull(builder.build());
     }
 
-    private void buildShouldThrowExceptionWithMessage(String operand) {
-        try {
-            builder.build();
-            Assert.fail("Should have failed with exception");
-        }
-        catch (IllegalStateException e){
-            Assert.assertThat(e.getMessage(), CoreMatchers.equalTo(operand));
-        }
+    @Test(expected = NullPointerException.class)
+    public void givenBuilderConstructedWithNullArg_whenBuildCalled_thenNullPointerIsThrown() {
+        Atam4j.Atam4jBuilder builder = new Atam4j.Atam4jBuilder(null);
+        builder.build();
     }
 
 }

--- a/src/test/java/me/atam/atam4j/Atam4jBuilderTest.java
+++ b/src/test/java/me/atam/atam4j/Atam4jBuilderTest.java
@@ -20,7 +20,7 @@ public class Atam4jBuilderTest {
     @Test
     public void givenBuilderNotSuppliedWithTestClasses_whenBuildCalled_thenExceptionThrown(){
         builder.withEnvironment(mock(Environment.class));
-        buildShouldThrowExceptionWithMessage("No test classes specified");
+        buildShouldThrowExceptionWithMessage("No test classes or annotation scanning specified");
     }
 
     @Test

--- a/src/test/java/me/atam/atam4j/Atam4jIntegrationTest.java
+++ b/src/test/java/me/atam/atam4j/Atam4jIntegrationTest.java
@@ -16,11 +16,9 @@ import static org.mockito.Mockito.when;
 
 public class Atam4jIntegrationTest {
 
-
     private Environment environment = mock(Environment.class);
     private LifecycleEnvironment lifeCycleEnvironment = new LifecycleEnvironment();
     private HealthCheckRegistry healthCheckRegistry = new HealthCheckRegistry();
-
 
     @Before
     public void setUp() throws Exception {
@@ -31,9 +29,8 @@ public class Atam4jIntegrationTest {
     @Test
     public void givenHealthCheckManagerWithPassingTest_whenInitialized_thenTestsAreHealthy() throws Exception{
 
-        new Atam4j.Atam4jBuilder()
-                .withTestClasses(new Class[]{PassingTest.class})
-                .withEnvironment(environment)
+        new Atam4j.Atam4jBuilder(environment)
+                .withTestClasses(PassingTest.class)
                 .withInitialDelay(0)
                 .build()
                 .initialise();

--- a/src/test/java/me/atam/atam4j/Atam4jIntegrationTest.java
+++ b/src/test/java/me/atam/atam4j/Atam4jIntegrationTest.java
@@ -42,6 +42,21 @@ public class Atam4jIntegrationTest {
         assertThat(getHealthCheckResult().isHealthy(), CoreMatchers.is(true));
     }
 
+    @Test
+    public void givenHealthCheckManagerUsingAnnotationScanning_whenInitialized_thenTestsAreHealthy() throws Exception{
+
+        new Atam4j.Atam4jBuilder(environment)
+                .withInitialDelay(0)
+                .build()
+                .initialise();
+
+        //nasty - this is so that the scheduler has run by the time we call the healthcheck
+        Thread.sleep(100);
+
+        assertThat(getHealthCheckResult().getMessage(), CoreMatchers.equalTo(AcceptanceTestsHealthCheck.OK_MESSAGE));
+        assertThat(getHealthCheckResult().isHealthy(), CoreMatchers.is(true));
+    }
+
     private HealthCheck.Result getHealthCheckResult() {
         return environment.healthChecks().runHealthCheck(AcceptanceTestsHealthCheck.NAME);
     }

--- a/src/test/java/me/atam/atam4j/LoggingEventWithThrowableMatcher.java
+++ b/src/test/java/me/atam/atam4j/LoggingEventWithThrowableMatcher.java
@@ -1,6 +1,5 @@
 package me.atam.atam4j;
 
-
 import org.hamcrest.Description;
 import org.hamcrest.Factory;
 import org.hamcrest.TypeSafeMatcher;
@@ -27,8 +26,4 @@ public class LoggingEventWithThrowableMatcher extends TypeSafeMatcher<LoggingEve
     public static LoggingEventWithThrowableMatcher hasThrowableThatContainsString(String message) {
         return new LoggingEventWithThrowableMatcher(message);
     }
-
-
-
-
 }

--- a/src/test/java/me/atam/atam4j/ignore/FailingTest.java
+++ b/src/test/java/me/atam/atam4j/ignore/FailingTest.java
@@ -6,10 +6,8 @@ import static org.junit.Assert.assertTrue;
 
 public class FailingTest {
 
-
     @Test
     public void testThatFails(){
         assertTrue("Was expecting false to be true",false);
     }
-
 }

--- a/src/test/java/me/atam/atam4j/ignore/PassingTest.java
+++ b/src/test/java/me/atam/atam4j/ignore/PassingTest.java
@@ -1,9 +1,11 @@
 package me.atam.atam4j.ignore;
 
+import me.atam.atam4j.Monitor;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
 
+@Monitor
 public class PassingTest {
 
     @Test

--- a/src/test/java/me/atam/atam4j/ignore/TestThatFailsOnInitialisation.java
+++ b/src/test/java/me/atam/atam4j/ignore/TestThatFailsOnInitialisation.java
@@ -7,17 +7,13 @@ import static org.junit.Assert.assertTrue;
 
 public class TestThatFailsOnInitialisation {
 
-
     @Before
     public void setUp() throws Exception {
         throw new RuntimeException("Nasty Exception on setUp()");
-
     }
 
     @Test
     public void testThatWouldPassIfRun(){
         assertTrue(true);
     }
-
-
 }


### PR DESCRIPTION
Instead of passing in an array of test classes to run, search for classes annotated with @Monitor (happy to change the name). I've kept the existing constructors that take a Class[] and made them package private for testing purposes. Closes #12.