### PR TITLE
Replace Environment with a HealthCheckRegistry

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,22 @@ instead of the tests classpath. This can be done by including them in the `src/m
 `src/test/java` directory. You can choose to either add a `@Monitor` annotation to your test classes and let atam4j 
 detect them or simply supply an array of classes to the builder.
 
-3. Instantiate `Atam4j` in the `run` method of your dropwizard application class.    
+3. Instantiate `Atam4j` in your application.    
 
     If specifying an explicit array of Test classes:
 
-        new Atam4j.Atam4jBuilder(environment)     
+        new Atam4j.Atam4jBuilder(metricsHealthCheckRegistry)     
             .withTestClasses(HelloWorldTest.class) 
             .build()      
             .initialise();
             
     If using `@Monitor` annotations to auto-detect test classes:            
             
-        new Atam4j.Atam4jBuilder(environment)      
+        new Atam4j.Atam4jBuilder(metricsHealthCheckRegistry)      
             .build()      
             .initialise();            
 
-4. Run the dropwizard app and observe the status of the acceptance tests reported under the health-check endpoint.
+4. Run your app and observe the status of the acceptance tests reported by the metrics health-check.
 
 Refer to [atam4j-sample-app](https://github.com/atam4j/atam4j-sample-app) for a complete working example.
 

--- a/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTaskScheduler.java
+++ b/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTaskScheduler.java
@@ -1,33 +1,37 @@
 package me.atam.atam4j;
 
-import io.dropwizard.setup.Environment;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import me.atam.atam4j.health.AcceptanceTestsState;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class AcceptanceTestsRunnerTaskScheduler {
 
-    private final Environment environment;
     private final Class[] testClasses;
     private final long initialDelay;
     private final long period;
     private final TimeUnit unit;
+    private final ScheduledExecutorService scheduler;
 
-    public AcceptanceTestsRunnerTaskScheduler(final Environment environment,
-                                              final Class[] testClasses,
+    public AcceptanceTestsRunnerTaskScheduler(final Class[] testClasses,
                                               final long initialDelay,
                                               final long period,
                                               final TimeUnit unit) {
-        this.environment = environment;
         this.testClasses = testClasses;
         this.initialDelay = initialDelay;
         this.period = period;
         this.unit = unit;
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder()
+                        .setNameFormat("acceptance-tests-runner")
+                        .setDaemon(false)
+                        .build());
     }
 
     public void scheduleAcceptanceTestsRunnerTask(final AcceptanceTestsState acceptanceTestsState) {
-        environment.lifecycle().
-                scheduledExecutorService("acceptance-tests-runner").build().scheduleAtFixedRate(
+        scheduler.scheduleAtFixedRate(
                 new AcceptanceTestsRunnerTask(acceptanceTestsState, testClasses),
                 initialDelay,
                 period,

--- a/src/main/java/me/atam/atam4j/Atam4j.java
+++ b/src/main/java/me/atam/atam4j/Atam4j.java
@@ -1,7 +1,7 @@
 package me.atam.atam4j;
 
+import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.common.base.Preconditions;
-import io.dropwizard.setup.Environment;
 import me.atam.atam4j.health.AcceptanceTestsHealthCheck;
 import me.atam.atam4j.health.AcceptanceTestsState;
 import org.reflections.Reflections;
@@ -15,32 +15,32 @@ import java.util.concurrent.TimeUnit;
 
 public class Atam4j {
 
-    private final Environment environment;
+    private final HealthCheckRegistry healthCheckRegistry;
     private final AcceptanceTestsState acceptanceTestsState = new AcceptanceTestsState();
     private final AcceptanceTestsRunnerTaskScheduler acceptanceTestsRunnerTaskScheduler;
 
     public Atam4j(final AcceptanceTestsRunnerTaskScheduler acceptanceTestsRunnerTaskScheduler,
-                  final Environment environment) {
+                  final HealthCheckRegistry healthCheckRegistry) {
         this.acceptanceTestsRunnerTaskScheduler = acceptanceTestsRunnerTaskScheduler;
-        this.environment = environment;
+        this.healthCheckRegistry = healthCheckRegistry;
     }
 
     public void initialise() {
         acceptanceTestsRunnerTaskScheduler.scheduleAcceptanceTestsRunnerTask(acceptanceTestsState);
         AcceptanceTestsHealthCheck healthCheck = new AcceptanceTestsHealthCheck(acceptanceTestsState);
-        environment.healthChecks().register(AcceptanceTestsHealthCheck.NAME, healthCheck);
+        healthCheckRegistry.register(AcceptanceTestsHealthCheck.NAME, healthCheck);
     }
 
     public static class Atam4jBuilder {
 
-        private Environment environment;
+        private HealthCheckRegistry healthCheckRegistry;
         private Optional<Class[]> testClasses = Optional.empty();
         private long initialDelay = 60;
         private long period = 300;
         private TimeUnit unit = TimeUnit.SECONDS;
 
-        public Atam4jBuilder(Environment environment) {
-            this.environment = Preconditions.checkNotNull(environment);
+        public Atam4jBuilder(HealthCheckRegistry healthCheckRegistry) {
+            this.healthCheckRegistry = Preconditions.checkNotNull(healthCheckRegistry);
         }
 
         public Atam4jBuilder withTestClasses(Class... testClasses) {
@@ -66,12 +66,11 @@ public class Atam4j {
         public Atam4j build() {
             return new Atam4j(
                     new AcceptanceTestsRunnerTaskScheduler(
-                        environment,
                         findTestClasses(),
                         initialDelay,
                         period,
                         unit),
-                    this.environment);
+                    healthCheckRegistry);
         }
 
         private Class[] findTestClasses() {

--- a/src/test/java/me/atam/atam4j/Atam4jBuilderTest.java
+++ b/src/test/java/me/atam/atam4j/Atam4jBuilderTest.java
@@ -1,16 +1,15 @@
 package me.atam.atam4j;
 
-import io.dropwizard.setup.Environment;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import me.atam.atam4j.ignore.PassingTest;
 import org.junit.Assert;
 import org.junit.Test;
-
-import static org.mockito.Mockito.mock;
 
 public class Atam4jBuilderTest {
 
     @Test
-    public void givenBuilderConstructedWithValidEnvironment_whenBuildCalled_thenManagerReturned() {
-        Atam4j.Atam4jBuilder builder = new Atam4j.Atam4jBuilder(mock(Environment.class));
+    public void givenBuilderConstructedWithHealthCheckRegistry_whenBuildCalled_thenManagerReturned() {
+        Atam4j.Atam4jBuilder builder = new Atam4j.Atam4jBuilder(new HealthCheckRegistry()).withTestClasses(PassingTest.class);
         Assert.assertNotNull(builder.build());
     }
 

--- a/src/test/java/me/atam/atam4j/Atam4jIntegrationTest.java
+++ b/src/test/java/me/atam/atam4j/Atam4jIntegrationTest.java
@@ -2,34 +2,21 @@ package me.atam.atam4j;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
-import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
-import io.dropwizard.setup.Environment;
 import me.atam.atam4j.health.AcceptanceTestsHealthCheck;
 import me.atam.atam4j.ignore.PassingTest;
 import org.hamcrest.CoreMatchers;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class Atam4jIntegrationTest {
 
-    private Environment environment = mock(Environment.class);
-    private LifecycleEnvironment lifeCycleEnvironment = new LifecycleEnvironment();
     private HealthCheckRegistry healthCheckRegistry = new HealthCheckRegistry();
-
-    @Before
-    public void setUp() throws Exception {
-        when(environment.lifecycle()).thenReturn(lifeCycleEnvironment);
-        when(environment.healthChecks()).thenReturn(healthCheckRegistry);
-    }
 
     @Test
     public void givenHealthCheckManagerWithPassingTest_whenInitialized_thenTestsAreHealthy() throws Exception{
 
-        new Atam4j.Atam4jBuilder(environment)
+        new Atam4j.Atam4jBuilder(healthCheckRegistry)
                 .withTestClasses(PassingTest.class)
                 .withInitialDelay(0)
                 .build()
@@ -45,7 +32,7 @@ public class Atam4jIntegrationTest {
     @Test
     public void givenHealthCheckManagerUsingAnnotationScanning_whenInitialized_thenTestsAreHealthy() throws Exception{
 
-        new Atam4j.Atam4jBuilder(environment)
+        new Atam4j.Atam4jBuilder(healthCheckRegistry)
                 .withInitialDelay(0)
                 .build()
                 .initialise();
@@ -58,6 +45,6 @@ public class Atam4jIntegrationTest {
     }
 
     private HealthCheck.Result getHealthCheckResult() {
-        return environment.healthChecks().runHealthCheck(AcceptanceTestsHealthCheck.NAME);
+        return healthCheckRegistry.runHealthCheck(AcceptanceTestsHealthCheck.NAME);
     }
 }


### PR DESCRIPTION
Before this change to create an instance of atam4j you had to pass in a dropwizard environment instance in order to register a health check and create a scheduler. I've replaced the need for an Environment with a HealthCheckRegistry instance and rolled our own scheduled executor. I've kept the dropwizard core dependency since we may need to expose http endpoints in the future to perform tasks/render views.
Resolves #32 