### PR TITLE
Issue 19 - add test failure details to healtcheck.message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.atam</groupId>
     <artifactId>atam4j</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0-SNAPSHOT</version>
 
     <name>${project.artifactId}</name>
     <description>Library that enables using acceptance tests as monitors</description>

--- a/src/main/java/me/atam/atam4j/health/AcceptanceTestsHealthCheck.java
+++ b/src/main/java/me/atam/atam4j/health/AcceptanceTestsHealthCheck.java
@@ -1,17 +1,21 @@
 package me.atam.atam4j.health;
 
 import com.codahale.metrics.health.HealthCheck;
-import org.junit.runner.notification.Failure;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Optional;
 
 public class AcceptanceTestsHealthCheck extends HealthCheck {
 
     public static final String TOO_EARLY_MESSAGE = "Too early to tell - tests not complete yet";
     public static final String OK_MESSAGE = "All is A OK!";
-    public static final String FAILURE_MESSAGE = "Number of failures:";
 
     private static AcceptanceTestsState testsState;
 
     public static final String NAME = "Acceptance Tests HealthCheck";
+
+    private final ObjectMapper mapper = new ObjectMapper();
 
     public AcceptanceTestsHealthCheck(AcceptanceTestsState acceptanceTestsState) {
         testsState = acceptanceTestsState;
@@ -23,16 +27,28 @@ public class AcceptanceTestsHealthCheck extends HealthCheck {
             if (testsState.getResult().get().wasSuccessful()) {
                 return AcceptanceTestsHealthCheck.Result.healthy(OK_MESSAGE);
             } else {
-                StringBuilder messageBuilder = new StringBuilder();
-                messageBuilder.append(String.format(FAILURE_MESSAGE + " %d.", testsState.getResult().get().getFailureCount()));
-                for (Failure failure : testsState.getResult().get().getFailures()) {
-                    messageBuilder.append(" ");
-                    messageBuilder.append(failure.getMessage());
-                }
-                return AcceptanceTestsHealthCheck.Result.unhealthy(messageBuilder.toString());
+                return AcceptanceTestsHealthCheck.Result.unhealthy(getTestRunReport());
             }
         } else {
             return AcceptanceTestsHealthCheck.Result.healthy(TOO_EARLY_MESSAGE);
         }
+    }
+
+
+    private String getTestRunReport() {
+        Optional<org.junit.runner.Result> testResultOpt = testsState.getResult();
+        if(testResultOpt.isPresent()) {
+            TestRunReport testRunReport = new TestRunReport(
+                    testResultOpt.get().getRunCount(),
+                    testResultOpt.get().getFailureCount(),
+                    testResultOpt.get().getFailures()
+            );
+            try {
+                return mapper.writeValueAsString(testRunReport);
+            } catch (JsonProcessingException e) {
+                return "Exception in generating test run report" + e.getMessage();
+            }
+        }
+        return "Test Result is empty";
     }
 }

--- a/src/main/java/me/atam/atam4j/health/FailedTest.java
+++ b/src/main/java/me/atam/atam4j/health/FailedTest.java
@@ -1,0 +1,25 @@
+package me.atam.atam4j.health;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class FailedTest {
+
+    private final String test;
+    private final String cause;
+
+    public FailedTest(@JsonProperty("test")String test,
+                      @JsonProperty("cause")String cause) {
+        this.test = test;
+        this.cause = cause;
+    }
+
+    public String getCause() {
+        return cause;
+    }
+
+    public String getTest() {
+        return test;
+    }
+}

--- a/src/main/java/me/atam/atam4j/health/TestRunReport.java
+++ b/src/main/java/me/atam/atam4j/health/TestRunReport.java
@@ -1,0 +1,44 @@
+package me.atam.atam4j.health;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.junit.runner.notification.Failure;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+
+public class TestRunReport {
+
+    @JsonProperty("testRunCount")
+    private int testRunCount;
+    @JsonProperty("testFailureCount")
+    private int testFailureCount;
+    @JsonProperty("failedTests")
+    private List<FailedTest> failedTests;
+
+    public TestRunReport(int testRunCount, int testFailureCount, List<Failure> failures) {
+        this.testRunCount = testRunCount;
+        this.testFailureCount = testFailureCount;
+
+        this.failedTests = failures.stream()
+                .map(failure -> new FailedTest(failure.getTestHeader(), failure.getMessage()))
+                .collect(Collectors.toList());
+    }
+    //needed by jackson for unmarshalling
+    protected TestRunReport() {
+    }
+
+    public int getTestRunCount() {
+        return testRunCount;
+    }
+
+    public int getTestFailureCount() {
+        return testFailureCount;
+    }
+
+    public List<FailedTest> getFailedTests() {
+        return failedTests;
+    }
+}

--- a/src/test/java/me/atam/atam4j/health/AcceptanceTestsHealthCheckTest.java
+++ b/src/test/java/me/atam/atam4j/health/AcceptanceTestsHealthCheckTest.java
@@ -1,54 +1,72 @@
 package me.atam.atam4j.health;
 
 import com.codahale.metrics.health.HealthCheck;
-import org.hamcrest.CoreMatchers;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 
-import java.util.ArrayList;
+import java.util.Collections;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class AcceptanceTestsHealthCheckTest {
 
-
+    private static final String DUMMY_FAILING_TEST = "failingTestMethod(me.atam4j.client.acceptancetests.TestClass)";
     private static final String DUMMY_TEST_FAILURE_MESSAGE = "Expected this but got that!";
+    public static final int TOTAL_TESTS_RUN = 2;
+    public static final int FAILED_TEST_COUNT = 1;
     Result result = mock(Result.class);
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     @Test
     public void givenTestsNotYetRun_whenHealthCheckCalled_thenTooEarlyMessageReceivedAndStatusIsOK()throws Exception{
         HealthCheck.Result healthCheckResult = new AcceptanceTestsHealthCheck(new AcceptanceTestsState()).check();
-        assertThat(healthCheckResult.getMessage(), CoreMatchers.equalTo(AcceptanceTestsHealthCheck.TOO_EARLY_MESSAGE));
-        assertThat(healthCheckResult.isHealthy(), CoreMatchers.equalTo(true));
+        assertThat(healthCheckResult.getMessage(), equalTo(AcceptanceTestsHealthCheck.TOO_EARLY_MESSAGE));
+        assertThat(healthCheckResult.isHealthy(), equalTo(true));
     }
 
     @Test
     public void givenTestsRunAndSuccessful_whenHealthCheckCalled_thenSuccessMessageReceived()throws Exception{
-        when(result.wasSuccessful()).thenReturn(true);
+        given(result.wasSuccessful()).willReturn(true);
         HealthCheck.Result healthCheckResult = new AcceptanceTestsHealthCheck(getAcceptanceTestsStateWithMockedResult()).check();
-        assertThat(healthCheckResult.getMessage(), CoreMatchers.equalTo(AcceptanceTestsHealthCheck.OK_MESSAGE));
-        assertThat(healthCheckResult.isHealthy(), CoreMatchers.equalTo(true));
+        assertThat(healthCheckResult.getMessage(), equalTo(AcceptanceTestsHealthCheck.OK_MESSAGE));
+        assertThat(healthCheckResult.isHealthy(), equalTo(true));
     }
 
     @Test
-    public void givenTestsFailed_whenHealthCheckCalled_thenFailureMessageReceived()throws Exception{
-        when(result.wasSuccessful()).thenReturn(false);
-        prepareResultWithFailure(DUMMY_TEST_FAILURE_MESSAGE);
+    public void givenTestRunHasAFailedTest_whenHealthCheckCalled_thenTestRunReportJsonIsReceived()throws Exception{
+        prepareResultWithAFailingTest(DUMMY_FAILING_TEST, DUMMY_TEST_FAILURE_MESSAGE);
         HealthCheck.Result healthCheckResult = new AcceptanceTestsHealthCheck(getAcceptanceTestsStateWithMockedResult()).check();
-        assertThat(healthCheckResult.getMessage(), CoreMatchers.equalTo(AcceptanceTestsHealthCheck.FAILURE_MESSAGE + " 1. " + DUMMY_TEST_FAILURE_MESSAGE));
-        assertThat(healthCheckResult.isHealthy(), CoreMatchers.equalTo(false));
+        assertThat(healthCheckResult.isHealthy(), equalTo(false));
+        String message = healthCheckResult.getMessage();
+        TestRunReport testRunReport = mapper.readValue(message, TestRunReport.class);
+        assertTestRunReportIncludesFailingTestDetails(testRunReport);
     }
 
-    private void prepareResultWithFailure(String testFailureMessage) {
-        ArrayList<Failure> value = new ArrayList<>();
+    private void prepareResultWithAFailingTest(String failingTest, String testFailureMessage) {
+        given(result.wasSuccessful()).willReturn(false);
+        given(result.getRunCount()).willReturn(TOTAL_TESTS_RUN);
+        given(result.getFailureCount()).willReturn(FAILED_TEST_COUNT);
+
         Failure failure = mock(Failure.class);
-        when(failure.getMessage()).thenReturn(testFailureMessage);
-        value.add(failure);
-        when(result.getFailureCount()).thenReturn(1);
-        when(result.getFailures()).thenReturn(value);
+        given(failure.getMessage()).willReturn(testFailureMessage);
+        given(failure.getTestHeader()).willReturn(failingTest);
+        when(result.getFailures()).thenReturn(Collections.singletonList(failure));
+    }
+
+    private void assertTestRunReportIncludesFailingTestDetails(TestRunReport testRunReport) {
+        assertThat(testRunReport.getTestRunCount(), is(TOTAL_TESTS_RUN));
+        assertThat(testRunReport.getTestFailureCount(), is(FAILED_TEST_COUNT));
+        assertThat(testRunReport.getFailedTests().size(), is(1));
+        FailedTest failedTest = testRunReport.getFailedTests().get(0);
+        assertThat(failedTest.getTest(), is(DUMMY_FAILING_TEST));
+        assertThat(failedTest.getCause(), is(DUMMY_TEST_FAILURE_MESSAGE));
     }
 
     private AcceptanceTestsState getAcceptanceTestsStateWithMockedResult() {


### PR DESCRIPTION
'Acceptance Tests HealthCheck' added by atam4j includes test run report as part of the healthcheck message when there are test failures.
```javascript
{
    "Acceptance Tests HealthCheck": {
        "healthy": false,
        "message": "{testRunReportJsonString}",
    "deadlocks": {
        "healthy": true
    }
}
```
'testRunReportJsonString' needs to be formatted using [jsonlint](http://jsonlint.com/) or a similar json formatter to make it readable as below:

```javascript
{
    "testRunCount": 9,
    "testFailureCount": 1,
    "failedTests": [
        {
            "test": "failingTestMethod(me.atam4j.client.acceptancetests.TestClass)",
            "cause": "Expected this but got that!"
        }
    ]
}
```