### PR TITLE
Improvements to logging and healthcheck message

### DIFF
--- a/acceptance-tests/src/test/java/me/atam/atam4jsampleapp/FailingTestAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/me/atam/atam4jsampleapp/FailingTestAcceptanceTest.java
@@ -11,7 +11,8 @@ public class FailingTestAcceptanceTest extends AcceptanceTest {
 
     @Test
     public void givenSampleApplicationStartedWithFailingTest_whenHealthCheckCalledBeforeTestRun_thenFailureMessageReceived() {
-        String expectedMessage = String.format("%s 1. Was expecting false to be true", AcceptanceTestsHealthCheck.FAILURE_MESSAGE);
+        String expectedMessage = String.format("%s 1. [testThatFails(me.atam.atam4j.dummytests.FailingTest) " +
+                "failed:\"Was expecting false to be true\"]", AcceptanceTestsHealthCheck.FAILURE_MESSAGE);
         applicationConfigurationDropwizardTestSupport = Atam4jApplicationStarter.startApplicationWith(FailingTest.class);
         new HealthCheckResponseChecker(getResponseFromHealthCheck()).checkResponseIsErrorAndWithMessage(expectedMessage);
     }

--- a/atam4j/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTask.java
+++ b/atam4j/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTask.java
@@ -29,9 +29,5 @@ public class AcceptanceTestsRunnerTask implements Runnable {
 
         final Result result = jUnitCore.run(testClasses);
         testsState.setResult(result);
-
-        for (Failure failure: result.getFailures()) {
-            LOGGER.error(failure.getDescription().toString(), failure.getException());
-        }
     }
 }

--- a/atam4j/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTask.java
+++ b/atam4j/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTask.java
@@ -1,13 +1,12 @@
 package me.atam.atam4j;
 
 import me.atam.atam4j.health.AcceptanceTestsState;
+import me.atam.atam4j.logging.LoggingListener;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Date;
 
 public class AcceptanceTestsRunnerTask implements Runnable {
 
@@ -24,17 +23,12 @@ public class AcceptanceTestsRunnerTask implements Runnable {
 
     @Override
     public void run() {
-        LOGGER.info("Starting tests at {}", new Date());
+        JUnitCore jUnitCore = new JUnitCore();
 
-        Result result = JUnitCore.runClasses(testClasses);
+        jUnitCore.addListener(new LoggingListener());
+
+        final Result result = jUnitCore.run(testClasses);
         testsState.setResult(result);
-
-        LOGGER.info("Tests finishes at {}", new Date());
-        LOGGER.info("Report :: total run = {}, failures = {}, in time = {} milliseconds",
-                result.getRunCount(),
-                result.getFailureCount(),
-                result.getRunTime()
-        );
 
         for (Failure failure: result.getFailures()) {
             LOGGER.error(failure.getDescription().toString(), failure.getException());

--- a/atam4j/src/main/java/me/atam/atam4j/health/AcceptanceTestsHealthCheck.java
+++ b/atam4j/src/main/java/me/atam/atam4j/health/AcceptanceTestsHealthCheck.java
@@ -24,11 +24,17 @@ public class AcceptanceTestsHealthCheck extends HealthCheck {
                 return AcceptanceTestsHealthCheck.Result.healthy(OK_MESSAGE);
             } else {
                 StringBuilder messageBuilder = new StringBuilder();
-                messageBuilder.append(String.format(FAILURE_MESSAGE + " %d.", testsState.getResult().get().getFailureCount()));
+                messageBuilder.append(String.format(FAILURE_MESSAGE + " %d. [", testsState.getResult().get().getFailureCount()));
+                String delimiter = "";
                 for (Failure failure : testsState.getResult().get().getFailures()) {
-                    messageBuilder.append(" ");
-                    messageBuilder.append(failure.getMessage());
+                    messageBuilder.append(
+                        String.format(
+                            "%s%s failed:\"%s\"", delimiter, failure.getTestHeader(), failure.getMessage()
+                        )
+                    );
+                    delimiter = ",";
                 }
+                messageBuilder.append("]");
                 return AcceptanceTestsHealthCheck.Result.unhealthy(messageBuilder.toString());
             }
         } else {

--- a/atam4j/src/main/java/me/atam/atam4j/logging/LoggingListener.java
+++ b/atam4j/src/main/java/me/atam/atam4j/logging/LoggingListener.java
@@ -1,0 +1,66 @@
+package me.atam.atam4j.logging;
+
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+
+public class LoggingListener extends RunListener {
+    private static Logger LOGGER = LoggerFactory.getLogger(LoggingListener.class);
+
+    @Override
+    public void testRunStarted(Description description) throws Exception {
+        LOGGER.info("Starting tests at {}", new Date());
+    }
+
+    @Override
+    public void testRunFinished(Result result) throws Exception {
+        LOGGER.info("Tests finishes at {}", new Date());
+        LOGGER.info("Report :: total run = {}, failures = {}, in time = {} milliseconds",
+                result.getRunCount(),
+                result.getFailureCount(),
+                result.getRunTime()
+        );
+    }
+
+    @Override
+    public void testStarted(Description description) throws Exception {
+        LOGGER.info("Starting {}", description.getDisplayName());
+    }
+
+    @Override
+    public void testFinished(Description description) throws Exception {
+        LOGGER.info("Finished {}", description.getDisplayName());
+    }
+
+    @Override
+    public void testFailure(Failure failure) throws Exception {
+        LOGGER.info(
+            String.format("Test %s failed: %s",
+                failure.getTestHeader(),
+                failure.getDescription()
+            ),
+            failure.getException()
+        );
+    }
+
+    @Override
+    public void testAssumptionFailure(Failure failure) {
+        LOGGER.info(
+            String.format("Test %s assumption failed: %s",
+                    failure.getTestHeader(),
+                    failure.getDescription()
+            ),
+            failure.getException()
+        );
+    }
+
+    @Override
+    public void testIgnored(Description description) throws Exception {
+        LOGGER.info("Test {} ignored: ", description.getDisplayName());
+    }
+}

--- a/atam4j/src/test/java/me/atam/atam4j/AcceptanceTestsRunnerTaskTest.java
+++ b/atam4j/src/test/java/me/atam/atam4j/AcceptanceTestsRunnerTaskTest.java
@@ -4,6 +4,7 @@ import me.atam.atam4j.dummytests.FailingTest;
 import me.atam.atam4j.dummytests.PassingTest;
 import me.atam.atam4j.dummytests.TestThatFailsOnInitialisation;
 import me.atam.atam4j.health.AcceptanceTestsState;
+import me.atam.atam4j.logging.LoggingListener;
 import org.junit.Test;
 import org.junit.runner.Result;
 import uk.org.lidalia.slf4jtest.TestLogger;
@@ -17,7 +18,7 @@ import static org.junit.Assert.assertTrue;
 public class AcceptanceTestsRunnerTaskTest {
 
     AcceptanceTestsState acceptanceTestsState = new AcceptanceTestsState();
-    TestLogger logger = TestLoggerFactory.getTestLogger(AcceptanceTestsRunnerTask.class);
+    TestLogger logger = TestLoggerFactory.getTestLogger(LoggingListener.class);
 
     @Test
     public void testPassingTestsRun(){

--- a/atam4j/src/test/java/me/atam/atam4j/health/AcceptanceTestsHealthCheckTest.java
+++ b/atam4j/src/test/java/me/atam/atam4j/health/AcceptanceTestsHealthCheckTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 public class AcceptanceTestsHealthCheckTest {
 
 
+    private static final String DUMMY_TEST_NAME = "dummyTestMethod(dummy.test.Class)";
     private static final String DUMMY_TEST_FAILURE_MESSAGE = "Expected this but got that!";
     Result result = mock(Result.class);
 
@@ -36,16 +37,23 @@ public class AcceptanceTestsHealthCheckTest {
     @Test
     public void givenTestsFailed_whenHealthCheckCalled_thenFailureMessageReceived()throws Exception{
         when(result.wasSuccessful()).thenReturn(false);
-        prepareResultWithFailure(DUMMY_TEST_FAILURE_MESSAGE);
+        prepareResultWithFailure(DUMMY_TEST_NAME, DUMMY_TEST_FAILURE_MESSAGE);
         HealthCheck.Result healthCheckResult = new AcceptanceTestsHealthCheck(getAcceptanceTestsStateWithMockedResult()).check();
-        assertThat(healthCheckResult.getMessage(), CoreMatchers.equalTo(AcceptanceTestsHealthCheck.FAILURE_MESSAGE + " 1. " + DUMMY_TEST_FAILURE_MESSAGE));
+        assertThat(
+                healthCheckResult.getMessage(),
+                CoreMatchers.equalTo(
+                        AcceptanceTestsHealthCheck.FAILURE_MESSAGE + " 1. ["
+                        + DUMMY_TEST_NAME + " failed:\"" + DUMMY_TEST_FAILURE_MESSAGE + "\"]"
+                )
+        );
         assertThat(healthCheckResult.isHealthy(), CoreMatchers.equalTo(false));
     }
 
-    private void prepareResultWithFailure(String testFailureMessage) {
+    private void prepareResultWithFailure(String testName, String testFailureMessage) {
         ArrayList<Failure> value = new ArrayList<>();
         Failure failure = mock(Failure.class);
         when(failure.getMessage()).thenReturn(testFailureMessage);
+        when(failure.getTestHeader()).thenReturn(testName);
         value.add(failure);
         when(result.getFailureCount()).thenReturn(1);
         when(result.getFailures()).thenReturn(value);


### PR DESCRIPTION
Here are some changes that should hopefully make it easier to debug test failures.

1. Ive moved most of the current logging to a JUnit listener, this means the failure logging appears inline with other logs generated by the tests rather than at the end of the test run.
2. Ive added start and end test messages, again this should help to make sense of other logs generated by the tests.
3. Ive modified the healthcheck message text to include the name of the tests that failed as well as the reasons for failure