### PR TITLE
Return the last complete result set

### DIFF
--- a/atam4j/src/main/java/me/atam/atam4j/TestRunListener.java
+++ b/atam4j/src/main/java/me/atam/atam4j/TestRunListener.java
@@ -17,19 +17,20 @@ import java.util.Objects;
 public class TestRunListener extends RunListener{
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TestRunListener.class);
-    private Map<TestIdentifier, IndividualTestResult> individualTestReportMap;
+    private Map<TestIdentifier, IndividualTestResult> testResults;
+    private Map<TestIdentifier, IndividualTestResult> previousTestResults;
     private boolean testsFinished = false;
-
 
     @Override
     public void testRunStarted(Description description) throws Exception {
-        individualTestReportMap =  new HashMap<>();
+        testResults =  new HashMap<>();
+        testsFinished = false;
     }
 
     @Override
     public void testStarted(Description description) throws Exception {
 
-        individualTestReportMap.put(
+        testResults.put(
                 new TestIdentifier(description),
                 new IndividualTestResult(
                         description.getClassName(),
@@ -41,15 +42,15 @@ public class TestRunListener extends RunListener{
 
     @Override
     public void testFailure(Failure failure) throws Exception {
-        IndividualTestResult individualTestResult = individualTestReportMap.get(new TestIdentifier(failure.getDescription()));
+        IndividualTestResult individualTestResult = testResults.get(new TestIdentifier(failure.getDescription()));
         individualTestResult.setPassed(false);
     }
 
-    public TestsRunResult getTestRunResult() {
+    public TestsRunResult getTestsRunResult() {
         if (!testsFinished) {
             return new TestsRunResult(TestsRunResult.Status.TOO_EARLY);
         }
-        return new TestsRunResult(individualTestReportMap.values());
+        return new TestsRunResult(testResults.values());
     }
 
     @Override

--- a/atam4j/src/main/java/me/atam/atam4j/resources/TestStatusResource.java
+++ b/atam4j/src/main/java/me/atam/atam4j/resources/TestStatusResource.java
@@ -21,7 +21,7 @@ public class TestStatusResource {
     @GET
     @Produces("application/json")
     public Response getTestStatus(){
-        TestsRunResult testRunResult = testRunListener.getTestRunResult();
+        TestsRunResult testRunResult = testRunListener.getTestsRunResult();
         if (testRunResult.getStatus().equals(TestsRunResult.Status.FAILURES)){
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(testRunResult).build();
         }
@@ -35,11 +35,11 @@ public class TestStatusResource {
 
         // filter out tests that don't match category
         testRunListener
-                .getTestRunResult()
+                .getTestsRunResult()
                 .getTests()
                 .removeIf(testResult -> !testResult.getCategory().equalsIgnoreCase(category));
 
-        TestsRunResult categorisedTestsResult = new TestsRunResult(testRunListener.getTestRunResult().getTests());
+        TestsRunResult categorisedTestsResult = new TestsRunResult(testRunListener.getTestsRunResult().getTests());
 
         if (categorisedTestsResult.getTests().size() <= 0) {
             return Response.status(Response.Status.NOT_FOUND).build();

--- a/atam4j/src/test/java/me/atam/atam4j/TestRunListenerTest.java
+++ b/atam4j/src/test/java/me/atam/atam4j/TestRunListenerTest.java
@@ -16,7 +16,7 @@ public class TestRunListenerTest {
 
     @Test
     public void givenTestRunNotFinished_whenGetTestRunResultCalled_thenStatusIsTooEarly() throws Exception {
-        assertThat(testRunListener.getTestRunResult().getStatus(), CoreMatchers.is(TestsRunResult.Status.TOO_EARLY));
+        assertThat(testRunListener.getTestsRunResult().getStatus(), CoreMatchers.is(TestsRunResult.Status.TOO_EARLY));
     }
 
     @Test
@@ -26,7 +26,7 @@ public class TestRunListenerTest {
         //given 2nd run
         testRunOf(() -> failingTest(getMockedTestDescription("testThatFails", "com.blah.MyTest")));
         //when
-        TestsRunResult secondResult = testRunListener.getTestRunResult();
+        TestsRunResult secondResult = testRunListener.getTestsRunResult();
         //then
         assertThat(secondResult.getStatus(), CoreMatchers.is(TestsRunResult.Status.FAILURES));
     }
@@ -46,7 +46,7 @@ public class TestRunListenerTest {
         //given 2nd run
         testRunOf(() -> passingTest(getMockedTestDescription("testThatPasses", "com.blah.MyTest")));
         //when
-        TestsRunResult secondResult = testRunListener.getTestRunResult();
+        TestsRunResult secondResult = testRunListener.getTestsRunResult();
         //then
         assertThat(secondResult.getStatus(), CoreMatchers.is(TestsRunResult.Status.ALL_OK));
     }
@@ -56,8 +56,8 @@ public class TestRunListenerTest {
         //given
         testRunOf(() -> passingTest(getMockedTestDescription("testThatPasses", "com.blah.MyTest")));
         //when then
-        assertThat(testRunListener.getTestRunResult().getStatus(), CoreMatchers.is(TestsRunResult.Status.ALL_OK));
-        assertThat(testRunListener.getTestRunResult().getTests().size(), CoreMatchers.is(1));
+        assertThat(testRunListener.getTestsRunResult().getStatus(), CoreMatchers.is(TestsRunResult.Status.ALL_OK));
+        assertThat(testRunListener.getTestsRunResult().getTests().size(), CoreMatchers.is(1));
     }
 
     @Test
@@ -67,8 +67,8 @@ public class TestRunListenerTest {
         //when
         testRunOf(() -> failingTest(testThatFails));
         //then
-        assertThat(testRunListener.getTestRunResult().getStatus(), CoreMatchers.is(TestsRunResult.Status.FAILURES));
-        assertThat(testRunListener.getTestRunResult().getTests().size(), CoreMatchers.is(1));
+        assertThat(testRunListener.getTestsRunResult().getStatus(), CoreMatchers.is(TestsRunResult.Status.FAILURES));
+        assertThat(testRunListener.getTestsRunResult().getTests().size(), CoreMatchers.is(1));
     }
 
     @Test
@@ -84,8 +84,8 @@ public class TestRunListenerTest {
         });
 
         //then
-        assertThat(testRunListener.getTestRunResult().getStatus(), CoreMatchers.is(TestsRunResult.Status.FAILURES));
-        assertThat(testRunListener.getTestRunResult().getTests().size(), CoreMatchers.is(2));
+        assertThat(testRunListener.getTestsRunResult().getStatus(), CoreMatchers.is(TestsRunResult.Status.FAILURES));
+        assertThat(testRunListener.getTestsRunResult().getTests().size(), CoreMatchers.is(2));
     }
 
     private Failure mockedFailureOf(Description testThatFails) {


### PR DESCRIPTION
instead of returning a partial result set when a test run is in progress