### PR TITLE
Fix 500 response when hitting /tests/{category} on startup 

### DIFF
--- a/acceptance-tests/src/test/java/me/atam/atam4jsampleapp/PassingTestAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/me/atam/atam4jsampleapp/PassingTestAcceptanceTest.java
@@ -35,6 +35,20 @@ public class PassingTestAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    public void givenSampleApplicationStartedWithPassingTest_whenCriticalHealthCheckCalledBeforeTestRun_thenTooEarlyMessageReceived(){
+
+        dropwizardTestSupportAppConfig = Atam4jApplicationStarter
+                .startApplicationWith(TEN_SECONDS_IN_MILLIS, PassingTest.class);
+
+        Response testRunResultFromServer = getCriticalTestRunResultFromServer();
+        assertThat(testRunResultFromServer.getStatus(), is(Response.Status.OK.getStatusCode()));
+        assertThat(
+                testRunResultFromServer.readEntity(TestsRunResult.class).getStatus(),
+                is(TestsRunResult.Status.TOO_EARLY)
+        );
+    }
+
+    @Test
     public void givenSampleApplicationStartedWithPassingTest_whenHealthCheckCalledAfterTestRUn_thenOKMessageReceived(){
 
         dropwizardTestSupportAppConfig = Atam4jApplicationStarter.startApplicationWith(0, PassingTest.class);

--- a/acceptance-tests/src/test/java/me/atam/atam4jsampleapp/testsupport/AcceptanceTest.java
+++ b/acceptance-tests/src/test/java/me/atam/atam4jsampleapp/testsupport/AcceptanceTest.java
@@ -5,23 +5,28 @@ import me.atam.atam4jsampleapp.ApplicationConfiguration;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.junit.After;
 
+import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 
 public abstract class AcceptanceTest {
 
+    private static final Client client = new JerseyClientBuilder().build();
     protected DropwizardTestSupport<ApplicationConfiguration> dropwizardTestSupportAppConfig;
-
 
     @After
     public void stopApplication() {
         dropwizardTestSupportAppConfig.after();
     }
 
-    public Response getTestRunResultFromServer(){
-        return new JerseyClientBuilder().build().target(
-                String.format("http://localhost:%d/tests", dropwizardTestSupportAppConfig.getLocalPort()))
+    public Response getTestRunResultFromServer() {
+        return client.target(String.format("http://localhost:%d/tests", dropwizardTestSupportAppConfig.getLocalPort()))
+                     .request()
+                     .get();
+    }
+
+    public Response getCriticalTestRunResultFromServer() {
+        return client.target(String.format("http://localhost:%d/tests/priority-1", dropwizardTestSupportAppConfig.getLocalPort()))
                 .request()
                 .get();
     }
-
 }

--- a/atam4j-domain/src/main/java/me/atam/atam4jdomain/TestsRunResult.java
+++ b/atam4j-domain/src/main/java/me/atam/atam4jdomain/TestsRunResult.java
@@ -3,32 +3,25 @@ package me.atam.atam4jdomain;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Collection;
-import java.util.List;
 
 public class TestsRunResult {
 
-    @JsonProperty
-    private Collection<IndividualTestResult> tests;
-    @JsonProperty
-    private Status status = Status.TOO_EARLY;
+    private final Collection<IndividualTestResult> tests;
+    private final Status status;
 
-
-    //for jackson
-    public TestsRunResult() {
-    }
-
-    public TestsRunResult(Status status) {
+    public TestsRunResult(final @JsonProperty("tests")  Collection<IndividualTestResult> tests,
+                          final @JsonProperty("status") Status status) {
+        this.tests = tests;
         this.status = status;
     }
 
-    public TestsRunResult(Collection<IndividualTestResult> tests) {
+    public TestsRunResult(final Collection<IndividualTestResult> tests) {
         this.tests = tests;
-        if (tests.parallelStream().filter(testReport -> !testReport.isPassed()).findAny().isPresent()){
-            this.status = Status.FAILURES;
-        }
-        else{
-            this.status = Status.ALL_OK;
-        }
+        this.status = tests.stream()
+                           .filter(testReport -> !testReport.isPassed())
+                           .findAny()
+                           .map(failures -> Status.FAILURES)
+                           .orElse(Status.ALL_OK);
     }
 
     public Collection<IndividualTestResult> getTests() {
@@ -39,15 +32,15 @@ public class TestsRunResult {
         return status;
     }
 
-    public static enum Status{
-        TOO_EARLY("Too early to tell - tests not complete yet"), ALL_OK("All is A OK!"), FAILURES("Failues");
+    public enum Status {
+        TOO_EARLY("Too early to tell - tests not complete yet"),
+        ALL_OK("All is A OK!"),
+        FAILURES("Failues");
 
-        private String message;
+        private final String message;
 
         Status(String message) {
             this.message = message;
         }
     }
-
-
 }


### PR DESCRIPTION
Return a 'to early to tell' 200 response for /tests/{category} just as the /tests endpoint does.
Resolves #70 