### PR TITLE
reducing the verbose of warn logging exception

### DIFF
--- a/atam4j/src/main/java/me/atam/atam4j/TestRunListener.java
+++ b/atam4j/src/main/java/me/atam/atam4j/TestRunListener.java
@@ -85,7 +85,7 @@ public class TestRunListener extends RunListener {
                 category = monitorCategory.name();
             }
         } catch (ClassNotFoundException | NoSuchMethodException e) {
-            LOGGER.warn("Test class or method not found", e);
+            LOGGER.warn("Test class or method not found cause={}", e.getMessage());
         }
 
         return category;


### PR DESCRIPTION
Parameterized tests are not recognized by getCategoryName method, hence causing verbose NoSuchMethodException to logged which may lead to debugging difficulties of failing tests.