### PR TITLE
Added ability to add JUnit custom listeners to test runs

### DIFF
--- a/acceptance-tests/src/main/java/me/atam/atam4jsampleapp/Atam4jTestApplication.java
+++ b/acceptance-tests/src/main/java/me/atam/atam4jsampleapp/Atam4jTestApplication.java
@@ -5,6 +5,7 @@ import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import me.atam.atam4j.Atam4j;
+import me.atam.atam4jsampleapp.resources.CustomListenerStatusResource;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
@@ -26,12 +27,15 @@ public class Atam4jTestApplication extends Application<ApplicationConfiguration>
 
     @Override
     public void run(final ApplicationConfiguration configuration, final Environment environment) throws Exception {
+        CustomListenerStatus customListenerStatus = new CustomListenerStatus();
         new Atam4j.Atam4jBuilder(environment.jersey())
                 .withUnit(TimeUnit.MILLISECONDS)
                 .withInitialDelay(configuration.getInitialDelayInMillis())
                 .withPeriod(configuration.getPeriodInMillis())
                 .withTestClasses(configuration.getTestClasses())
+                .withListener(new CustomListener(customListenerStatus))
                 .build()
                 .initialise();
+        environment.jersey().register(new CustomListenerStatusResource(customListenerStatus));
     }
 }

--- a/acceptance-tests/src/main/java/me/atam/atam4jsampleapp/CustomListener.java
+++ b/acceptance-tests/src/main/java/me/atam/atam4jsampleapp/CustomListener.java
@@ -1,0 +1,19 @@
+package me.atam.atam4jsampleapp;
+
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunListener;
+
+public class CustomListener extends RunListener {
+
+    private CustomListenerStatus customListenerStatus;
+
+    public CustomListener(CustomListenerStatus customListenerStatus) {
+        this.customListenerStatus = customListenerStatus;
+    }
+
+    @Override
+    public void testRunStarted(Description description) throws Exception {
+        super.testRunStarted(description);
+        customListenerStatus.setStarted(true);
+    }
+}

--- a/acceptance-tests/src/main/java/me/atam/atam4jsampleapp/CustomListenerStatus.java
+++ b/acceptance-tests/src/main/java/me/atam/atam4jsampleapp/CustomListenerStatus.java
@@ -1,0 +1,17 @@
+package me.atam.atam4jsampleapp;
+
+public class CustomListenerStatus {
+    private boolean started;
+
+    public boolean isStarted() {
+        return started;
+    }
+
+    public void setStarted(boolean started) {
+        this.started = started;
+    }
+
+    public CustomListenerStatus() {
+        this.started = false;
+    }
+}

--- a/acceptance-tests/src/main/java/me/atam/atam4jsampleapp/resources/CustomListenerStatusResource.java
+++ b/acceptance-tests/src/main/java/me/atam/atam4jsampleapp/resources/CustomListenerStatusResource.java
@@ -1,0 +1,18 @@
+package me.atam.atam4jsampleapp.resources;
+
+import me.atam.atam4jsampleapp.CustomListenerStatus;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path("/customlistenerstatus")
+@Produces("application/json")
+public class CustomListenerStatusResource {
+    private final CustomListenerStatus customListenerStatus;
+
+    public CustomListenerStatusResource(CustomListenerStatus customListenerStatus) { this.customListenerStatus = customListenerStatus; }
+
+    @GET
+    public CustomListenerStatus getAcceptanceTestRunListenerStatus() { return customListenerStatus; }
+}

--- a/acceptance-tests/src/test/java/me/atam/atam4jsampleapp/CustomListenerTest.java
+++ b/acceptance-tests/src/test/java/me/atam/atam4jsampleapp/CustomListenerTest.java
@@ -1,0 +1,27 @@
+package me.atam.atam4jsampleapp;
+
+import me.atam.atam4j.dummytests.PassingTestWithNoCategory;
+import me.atam.atam4jsampleapp.testsupport.AcceptanceTest;
+import me.atam.atam4jsampleapp.testsupport.Atam4jApplicationStarter;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import static me.atam.atam4jsampleapp.testsupport.AcceptanceTestTimeouts.TEN_SECONDS_IN_MILLIS;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class CustomListenerTest extends AcceptanceTest {
+    @Test
+    public void givenAConfiguredCustomLister_whenTestsAreRun_thenListenerCallbacksWillBeCalled() {
+        //given
+        dropwizardTestSupportAppConfig = Atam4jApplicationStarter
+                .startApplicationWith(TEN_SECONDS_IN_MILLIS, PassingTestWithNoCategory.class, 1);
+        //when
+        Response customListenerStatusResponse = getCustomListenerStatusOnceTestsRunHasCompleted();
+
+        //then
+        assertThat(customListenerStatusResponse.getStatus(), is(Response.Status.OK.getStatusCode()));
+        assertThat(customListenerStatusResponse.readEntity(CustomListenerStatus.class).isStarted(), is(true));
+    }
+}

--- a/acceptance-tests/src/test/java/me/atam/atam4jsampleapp/testsupport/AcceptanceTest.java
+++ b/acceptance-tests/src/test/java/me/atam/atam4jsampleapp/testsupport/AcceptanceTest.java
@@ -43,6 +43,15 @@ public abstract class AcceptanceTest {
         return getTestRunResultFromServer(getTestsURI());
     }
 
+    public Response getCustomListenerStatusOnceTestsRunHasCompleted() {
+        waitUntilTestRunHasCompleted();
+        return getTestRunResultFromServer(getCustomListenerStatusURI());
+    }
+
+    public String getCustomListenerStatusURI() {
+        return String.format("http://localhost:%d/customlistenerstatus", dropwizardTestSupportAppConfig.getLocalPort());
+    }
+
     private void waitUntilTestRunHasCompleted() {
         PollingPredicate<Response> responsePollingPredicate = new PollingPredicate<>(
                 MAX_ATTEMPTS,

--- a/atam4j/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTask.java
+++ b/atam4j/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTask.java
@@ -4,19 +4,22 @@ import me.atam.atam4j.health.AcceptanceTestsState;
 import me.atam.atam4j.logging.LoggingListener;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
+import org.junit.runner.notification.RunListener;
+
+import java.util.List;
 
 public class AcceptanceTestsRunnerTask implements Runnable {
 
     private final AcceptanceTestsState testsState;
     private final Class[] testClasses;
-    private TestRunListener testRunListener;
+    private List<RunListener> runListeners;
 
     AcceptanceTestsRunnerTask(final AcceptanceTestsState testsState,
-                              final TestRunListener testRunListener,
+                              final List<RunListener> runListeners,
                               final Class... testClasses) {
         this.testsState = testsState;
         this.testClasses = testClasses;
-        this.testRunListener = testRunListener;
+        this.runListeners = runListeners;
     }
 
     @Override
@@ -25,7 +28,9 @@ public class AcceptanceTestsRunnerTask implements Runnable {
 
         jUnitCore.addListener(new LoggingListener());
 
-        jUnitCore.addListener(testRunListener);
+        for (RunListener runListener : runListeners) {
+            jUnitCore.addListener(runListener);
+        }
 
         final Result result = jUnitCore.run(testClasses);
         testsState.setResult(result);

--- a/atam4j/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTaskScheduler.java
+++ b/atam4j/src/main/java/me/atam/atam4j/AcceptanceTestsRunnerTaskScheduler.java
@@ -2,7 +2,9 @@ package me.atam.atam4j;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import me.atam.atam4j.health.AcceptanceTestsState;
+import org.junit.runner.notification.RunListener;
 
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -14,18 +16,18 @@ public class AcceptanceTestsRunnerTaskScheduler {
     private final long period;
     private final TimeUnit unit;
     private final ScheduledExecutorService scheduler;
-    private final TestRunListener testRunListener;
+    private final List<RunListener> runListeners;
 
     public AcceptanceTestsRunnerTaskScheduler(final Class[] testClasses,
                                               final long initialDelay,
                                               final long period,
                                               final TimeUnit unit,
-                                              final TestRunListener testRunListener) {
+                                              final List<RunListener> runListeners) {
         this.testClasses = testClasses;
         this.initialDelay = initialDelay;
         this.period = period;
         this.unit = unit;
-        this.testRunListener = testRunListener;
+        this.runListeners = runListeners;
         this.scheduler = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder()
                         .setNameFormat("acceptance-tests-runner")
@@ -35,7 +37,7 @@ public class AcceptanceTestsRunnerTaskScheduler {
 
     public void scheduleAcceptanceTestsRunnerTask(final AcceptanceTestsState acceptanceTestsState) {
         scheduler.scheduleAtFixedRate(
-                new AcceptanceTestsRunnerTask(acceptanceTestsState, testRunListener, testClasses),
+                new AcceptanceTestsRunnerTask(acceptanceTestsState, runListeners, testClasses),
                 initialDelay,
                 period,
                 unit);

--- a/atam4j/src/test/java/me/atam/atam4j/AcceptanceTestsRunnerTaskTest.java
+++ b/atam4j/src/test/java/me/atam/atam4j/AcceptanceTestsRunnerTaskTest.java
@@ -10,10 +10,9 @@ import org.junit.runner.Result;
 import uk.org.lidalia.slf4jtest.TestLogger;
 import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class AcceptanceTestsRunnerTaskTest {
 
@@ -43,7 +42,7 @@ public class AcceptanceTestsRunnerTaskTest {
     }
 
     private Result runTestsAndGetResult(Class... passingTests) {
-        new AcceptanceTestsRunnerTask(acceptanceTestsState, new TestRunListener(), passingTests).run();
+        new AcceptanceTestsRunnerTask(acceptanceTestsState, asList(new TestRunListener()), passingTests).run();
         return acceptanceTestsState.getResult().get();
     }
 }


### PR DESCRIPTION
This pull request extends Atam4j to support custom test listeners for the test runs.

We are trying to migrate our tests to Atam4j, and we currenlty use listeners to set test identifiers in thread local storage, which we use to improve logging and traceability of the requests that the acceptance tests make.

We tried to implement this using Rules, but for certain tests e.g. JUnitParams tests, this approach does not work. Therefore, our current best option is to use test listeners.

Test listeners are a standard feature of JUnit and it seems like a useful addition to Atam4j.